### PR TITLE
Play audio alert when user is addressed

### DIFF
--- a/client/scripts/game-logic/engine.js
+++ b/client/scripts/game-logic/engine.js
@@ -292,6 +292,11 @@ define([
             //The chat only renders if the Arr length is diff, remove blocks of the array
             if (self.chat.length > AppConstants.Chat.MAX_LENGTH)
                 self.chat.splice(0, 400);
+
+            var r = new RegExp('^\\s*' + self.username + ':');
+            if (data.type === 'say' && data.username !== self.username && r.test(data.message)) {
+                new Audio('http://soundbible.com/mp3/A-Tone-His_Self-1266414414.mp3').play();
+            }
             self.chat.push(data);
 
             self.trigger('msg', data);


### PR DESCRIPTION
You might want to use a different notification sound and/or host it yourself.

Although technically an `Audio` should play the sound every time `play()` is called, in most browsers (Webkit at the very least) it only actually plays on the first call. For that reason we need to create a new one on the fly every time we want to play the notification sound. The file itself is cached, however, so it's not an issue.